### PR TITLE
Adds default size to tmux panes to avoid errors with too many hosts

### DIFF
--- a/lib/App/MultiSsh.pm
+++ b/lib/App/MultiSsh.pm
@@ -183,9 +183,10 @@ sub tmux {
 
     my $layout = layout(@commands);
     my $tmux   = '';
+    my $pct    = int( 100 / scalar @commands );
 
     for my $ssh (@commands) {
-        my $cmd = !$tmux ? 'new-session' : '\\; split-window -d';
+        my $cmd = !$tmux ? 'new-session' : '\\; split-window -d -p ' . $pct;
 
         $tmux .= " $cmd " . shell_quote($ssh);
     }

--- a/t/tmux.t
+++ b/t/tmux.t
@@ -70,10 +70,10 @@ sub test_layout {
 sub test_tmux {
     my @data = (
         q{tmux new-session 'cmd1 ' \\; select-layout tiled \\; setw synchronize-panes},
-        q{tmux new-session 'cmd1 ' \\; split-window -d 'cmd2 ' \\; select-layout tiled \\; setw synchronize-panes},
-        q{tmux new-session 'cmd1 ' \\; split-window -d 'cmd2 ' \\; split-window -d 'cmd3 ' \\; select-layout tiled \\; setw synchronize-panes},
-        q{tmux new-session 'cmd1 ' \\; split-window -d 'cmd2 ' \\; split-window -d 'cmd3 ' \\; split-window -d 'cmd4 ' \\; select-layout tiled \\; setw synchronize-panes},
-        q{tmux new-session 'cmd1 ' \\; split-window -d 'cmd2 ' \\; split-window -d 'cmd3 ' \\; split-window -d 'cmd4 ' \\; split-window -d 'cmd5 ' \\; select-layout tiled \\; setw synchronize-panes},
+        q{tmux new-session 'cmd1 ' \\; split-window -d -p 50 'cmd2 ' \\; select-layout tiled \\; setw synchronize-panes},
+        q{tmux new-session 'cmd1 ' \\; split-window -d -p 33 'cmd2 ' \\; split-window -d -p 33 'cmd3 ' \\; select-layout tiled \\; setw synchronize-panes},
+        q{tmux new-session 'cmd1 ' \\; split-window -d -p 25 'cmd2 ' \\; split-window -d -p 25 'cmd3 ' \\; split-window -d -p 25 'cmd4 ' \\; select-layout tiled \\; setw synchronize-panes},
+        q{tmux new-session 'cmd1 ' \\; split-window -d -p 20 'cmd2 ' \\; split-window -d -p 20 'cmd3 ' \\; split-window -d -p 20 'cmd4 ' \\; split-window -d -p 20 'cmd5 ' \\; select-layout tiled \\; setw synchronize-panes},
     );
 
     for my $no (0 .. $#data) {


### PR DESCRIPTION
- tmux will not allow the splitting of panes that are below a certain
  size. If we continually split a pane it will eventually be too small
  and the next split will fail.
- This patch adds the -p parameter and allocates the window sizes
  equally among all hosts.
